### PR TITLE
add "copy" action and menu item

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,6 @@ jobs:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
       - run: sudo apt-get update && sudo apt-get install -y xorg-dev mesa-utils xvfb libgl1 freeglut3-dev libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev xsettingsd x11-xserver-utils
-      - name: Cache artifacts
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Gtk4Makie"
 uuid = "478199e7-b407-4926-87ea-7196203a28d8"
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
@@ -31,5 +31,5 @@ Makie = "0.20"
 ModernGL = "1"
 PrecompileTools = "1"
 Preferences = "1"
-ShaderAbstractions = "0.3, 0.4"
+ShaderAbstractions = "0.4"
 julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -66,4 +66,3 @@ The `push!` function adds a Makie `Figure` to the widget.
 
 ### Bonus functionality
 A window showing the axes and plots in a figure and their attributes can be opened using `attributes_window(f=current_figure())`. This can be used to experiment with various attributes, or add axis labels and titles before saving a plot. This functionality is experimental, buggy, and likely to grow and evolve over time.
-

--- a/src/settings_widgets.jl
+++ b/src/settings_widgets.jl
@@ -42,7 +42,10 @@ end
 function activated_cb_num(p::Ptr, user_data)
     obs, T = user_data
     entry = convert(GtkEntry,p)
-    obs[] = parse(T, Gtk4.G_.get_text(entry))
+    try
+        obs[] = parse(T, Gtk4.G_.get_text(entry))
+    catch e
+    end
     nothing
 end
 


### PR DESCRIPTION
For copying the plot into the clipboard (as a PNG).

Also fix an issue with the entry widget.